### PR TITLE
Feature: pay interest

### DIFF
--- a/pallets/pallet-bank/src/mock.rs
+++ b/pallets/pallet-bank/src/mock.rs
@@ -8,6 +8,7 @@ use frame_support::{
     traits::{ConstU32, ConstU64, Everything},
 };
 
+use primitives::YEAR;
 use sp_runtime::{testing::H256, traits::IdentityLookup, BuildStorage};
 
 use crate as pallet_bank;
@@ -21,7 +22,12 @@ pub const TREASURY: AccountId = 0;
 pub const ED: u128 = 3u128;
 pub const MIN: u128 = 5u128;
 pub const INITIAL_BALANCE: u128 = 1_000_000u128;
-pub const REDEEM_PERIOD: u64 = 10;
+pub const REDEEM_PERIOD: u64 = 200;
+pub const STAKE_PERIOD: u64 = 150;
+pub const INTEREST_PAYOUT_PERIOD: u64 = 100;
+
+type Block = frame_system::mocking::MockBlock<Runtime>;
+type BlockNumber = u64;
 
 impl frame_system::Config for Runtime {
     type RuntimeOrigin = RuntimeOrigin;
@@ -53,7 +59,10 @@ parameter_types! {
     pub const ExistentialDeposit: Balance = ED;
     pub const TreasuryAccount: AccountId = TREASURY;
     pub const MinimumAmount: Balance = MIN;
-    pub const RedeemPeriod: BlockNumberFor<Runtime> = REDEEM_PERIOD;
+    pub const RedeemPeriod: BlockNumber = REDEEM_PERIOD;
+    pub const StakePeriod: BlockNumber = STAKE_PERIOD;
+    pub const InterestPayoutPeriod: BlockNumber = INTEREST_PAYOUT_PERIOD;
+    pub const TotalBlocksPerYear: BlockNumber = YEAR as BlockNumber;
 }
 
 impl Config for Runtime {
@@ -65,13 +74,14 @@ impl Config for Runtime {
     type TreasuryAccount = TreasuryAccount;
     type MinimumAmount = MinimumAmount;
     type RedeemPeriod = RedeemPeriod;
+    type StakePeriod = StakePeriod;
+    type InterestPayoutPeriod = InterestPayoutPeriod;
+    type TotalBlocksPerYear = TotalBlocksPerYear;
 }
 
 impl pallet_roles::Config for Runtime {
     type RuntimeEvent = RuntimeEvent;
 }
-
-type Block = frame_system::mocking::MockBlock<Runtime>;
 
 construct_runtime!(
     pub enum Runtime

--- a/pallets/pallet-bank/src/tests.rs
+++ b/pallets/pallet-bank/src/tests.rs
@@ -4,7 +4,8 @@
 
 use crate::mock::{
     default_test_ext, AccountId, Bank, MockGenesisConfig, Roles, Runtime, RuntimeEvent,
-    RuntimeOrigin, StakePeriod, System, TreasuryAccount, ALICE, BOB, REDEEM_PERIOD,
+    RuntimeOrigin, StakePeriod, System, TreasuryAccount, ALICE, BOB, INTEREST_PAYOUT_PERIOD,
+    REDEEM_PERIOD,
 };
 use crate::*;
 use frame_support::{assert_err, assert_noop, assert_ok};
@@ -408,5 +409,66 @@ fn auditor_cannot_unlock_invalid_id() {
                 Bank::unlock_funds_auditor(RuntimeOrigin::signed(charlie), ALICE, 200),
                 crate::Error::<Runtime>::InvalidLockId
             );
+        });
+}
+
+#[test]
+fn manager_can_set_interest_rate() {
+    MockGenesisConfig::with_balances(vec![(ALICE, 1_000)])
+        .build()
+        .execute_with(|| {
+            let charlie: AccountId = 3u32;
+            assert_ok!(Roles::register_role(&charlie, Role::Manager));
+            assert_ok!(Bank::set_interest_rate(RuntimeOrigin::signed(charlie), 500));
+            assert_eq!(InterestRate::<Runtime>::get(), Perbill::from_percent(5));
+        });
+}
+
+#[test]
+fn incorrect_role_cannot_set_interest_rate() {
+    MockGenesisConfig::with_balances(vec![(ALICE, 1_000)])
+        .build()
+        .execute_with(|| {
+            let charlie: AccountId = 3u32;
+            assert_ok!(Roles::register_role(&charlie, Role::Auditor));
+            assert_err!(
+                Bank::set_interest_rate(RuntimeOrigin::signed(charlie), 500),
+                pallet_roles::Error::<Runtime>::IncorrectRole
+            );
+            assert_err!(
+                Bank::set_interest_rate(RuntimeOrigin::signed(ALICE), 500),
+                pallet_roles::Error::<Runtime>::IncorrectRole
+            );
+            assert!(InterestRate::<Runtime>::get().is_zero());
+        });
+}
+
+#[test]
+fn pay_interest() {
+    MockGenesisConfig::with_balances(vec![(ALICE, 1_000_000_000)])
+        .build()
+        .execute_with(|| {
+            let charlie: AccountId = 3u32;
+            assert_ok!(Roles::register_role(&charlie, Role::Manager));
+            assert_ok!(Bank::set_interest_rate(RuntimeOrigin::signed(charlie), 500));
+            assert_ok!(Bank::stake_funds(
+                RuntimeOrigin::signed(ALICE),
+                1_000_000_000
+            ));
+            Bank::on_finalize(System::block_number() + StakePeriod::get());
+            Bank::on_finalize(INTEREST_PAYOUT_PERIOD);
+            assert_eq!(
+                Accounts::<Runtime>::get(&ALICE),
+                AccountData {
+                    free: 0,
+                    reserved: 1_000_000_951,
+                    locked: vec![]
+                }
+            );
+            System::assert_last_event(RuntimeEvent::Bank(Event::<Runtime>::InterestPayed {
+                interest_rate: Perbill::from_percent(5),
+                total_interest_payed: 951,
+            }));
+            assert!(Bank::check_total_issuance());
         });
 }

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -1,0 +1,13 @@
+#![allow(dead_code)]
+
+/// Defines all the constants for the project
+use crate::BlockNumber;
+
+// 6 seconds per block, same as Polkadot
+pub const SECONDS_PER_BLOCK: BlockNumber = 6u32;
+
+// approx. number of seconds in a year: 365 * 24 * 3600
+pub const SECONDS_PER_YEAR: BlockNumber = 31_536_000u32;
+
+pub const DAY: BlockNumber = 86_400 / SECONDS_PER_BLOCK;
+pub const YEAR: BlockNumber = SECONDS_PER_YEAR / SECONDS_PER_BLOCK;

--- a/primitives/src/lib.rs
+++ b/primitives/src/lib.rs
@@ -13,6 +13,9 @@ use sp_runtime::{
 };
 use sp_std::prelude::*;
 
+pub mod constants;
+pub use constants::*;
+
 #[cfg(feature = "std")]
 use serde::{Deserialize, Serialize};
 


### PR DESCRIPTION
Closes #7 

Add a function set_interest_rate, only managers can set interest rate.
Pay interest in every interest_rate_payout_period.
The stake will lock the fund for stake_period, and then go to reserved.