### PR TITLE
fixed rotate-treasury()

### DIFF
--- a/pallets/pallet-bank/src/lib.rs
+++ b/pallets/pallet-bank/src/lib.rs
@@ -167,7 +167,7 @@ pub mod module {
 		InterestPayed { interest_rate: Perbill, total_interest_payed: T::Balance },
 
 		/// TreasuryAccount rotated.
-		TreasuryAccountRotated { old: T::AccountId, new: T::AccountId },
+		TreasuryAccountRotated { old: Option<T::AccountId>, new: T::AccountId },
 	}
 
 	/// The balance of a token type under an account.
@@ -434,24 +434,40 @@ pub mod module {
 			Ok(())
 		}
 
+		/// Migrate the old treasury account to a new one.
+		///
+		/// Requires Root.
 		#[pallet::call_index(8)]
 		#[pallet::weight(T::WeightInfo::rotate_treasury())]
 		pub fn rotate_treasury(origin: OriginFor<T>, new_treasury: T::AccountId) -> DispatchResult {
 			ensure_root(origin)?;
 			ensure!(!Accounts::<T>::contains_key(&new_treasury), Error::<T>::AccountIdAlreadyTaken);
-			let old_treasury = Self::treasury()?;
-			// Update lock expiry of old treasury to the new treasury account.
-			AccountWithUnlockedFund::<T>::iter().for_each(|(block_number, mut accounts)| {
-				accounts.iter_mut().for_each(|(user_id, _)| {
-					if *user_id == old_treasury {
-						*user_id = new_treasury.clone();
-					}
-				});
-				// Update the storage map with the modified accounts
-				AccountWithUnlockedFund::<T>::insert(block_number, accounts);
-			});
+			ensure!(
+				T::RoleManager::role(&new_treasury).is_none(),
+				Error::<T>::AccountIdAlreadyTaken
+			);
 
-			Accounts::<T>::insert(&new_treasury, Accounts::<T>::take(&old_treasury));
+			let old_treasury = match Self::treasury() {
+				Ok(treasury) => {
+					// Update lock expiry of old treasury to the new treasury account.
+					AccountWithUnlockedFund::<T>::iter().for_each(
+						|(block_number, mut accounts)| {
+							accounts.iter_mut().for_each(|(user_id, _)| {
+								if *user_id == treasury {
+									*user_id = new_treasury.clone();
+								}
+							});
+							// Update the storage map with the modified accounts
+							AccountWithUnlockedFund::<T>::insert(block_number, accounts);
+						},
+					);
+
+					Accounts::<T>::insert(&new_treasury, Accounts::<T>::take(&treasury));
+					Some(treasury)
+				},
+				Err(_) => None, // Set old_treasury to None if treasury() returns an error
+			};
+
 			TreasuryAccount::<T>::set(Some(new_treasury.clone()));
 			Self::deposit_event(Event::<T>::TreasuryAccountRotated {
 				old: old_treasury,

--- a/primitives/src/constants.rs
+++ b/primitives/src/constants.rs
@@ -20,5 +20,3 @@ pub const MINUTES: BlockNumber = 60_000 / (MILLISECS_PER_BLOCK as BlockNumber);
 pub const HOURS: BlockNumber = MINUTES * 60;
 pub const DAYS: BlockNumber = HOURS * 24;
 pub const YEAR: BlockNumber = DAYS * 365;
-
-pub const TREASURY: [u8; 32] = [0xFF; 32];

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -45,9 +45,7 @@ use pallet_transaction_payment::{ConstFeeMultiplier, CurrencyAdapter, Multiplier
 pub use sp_runtime::BuildStorage;
 pub use sp_runtime::{Perbill, Permill};
 
-use primitives::{
-	AccountId, Balance, BlockNumber, Hash, Nonce, Signature, SLOT_DURATION, TREASURY, YEAR,
-};
+use primitives::{AccountId, Balance, BlockNumber, Hash, Nonce, Signature, SLOT_DURATION, YEAR};
 
 /// Opaque types. These are used by the CLI to instantiate machinery that don't need to know
 /// the specifics of the runtime. They can then be made to be agnostic over specific formats
@@ -219,14 +217,12 @@ impl pallet_sudo::Config for Runtime {
 
 pub const ED: u128 = 3u128;
 pub const MIN: u128 = 5u128;
-pub const INITIAL_BALANCE: u128 = 1_000_000u128;
 pub const REDEEM_PERIOD: u32 = 200;
 pub const STAKE_PERIOD: u32 = 150;
 pub const INTEREST_PAYOUT_PERIOD: u32 = 100;
 
 parameter_types! {
 	pub const ExistentialDeposit: Balance = ED;
-	pub TreasuryAccount: AccountId = TREASURY.into();
 	pub const MinimumAmount: Balance = MIN;
 	pub const RedeemPeriod: BlockNumber = REDEEM_PERIOD;
 	pub const StakePeriod: BlockNumber = STAKE_PERIOD;


### PR DESCRIPTION
Close #40 

Fixed rotate_treasury(root, new_treasury), when the treasury account is not set, set it with the new_treasury account id.
Added test, make sure treasury account can be set successfully.