### PR TITLE
feature/use macro create test accounts

### DIFF
--- a/integration-tests/src/bank.rs
+++ b/integration-tests/src/bank.rs
@@ -42,3 +42,17 @@ fn can_set_and_accrue_interest_rate() {
 		println!("{}", Gov0);
 	});
 }
+
+#[test]
+fn can_print_test_accounts() {
+	ExtBuilder::default().build().execute_with(|| {
+		assert_eq!(
+			Gov0.to_string(),
+			"Gov0: 0xf0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0"
+		);
+		assert_eq!(
+			Alice.to_string(),
+			"Alice: 0x0000000000000000000000000000000000000000000000000000000000000000"
+		);
+	});
+}

--- a/integration-tests/src/bank.rs
+++ b/integration-tests/src/bank.rs
@@ -4,39 +4,41 @@ use crate::*;
 fn can_set_and_accrue_interest_rate() {
 	ExtBuilder::default().build().execute_with(|| {
 		// Set interest rate to 10%
-		assert_ok!(Bank::set_interest_rate(RuntimeOrigin::signed(MANAGER.into()), 1_000u32));
+		assert_ok!(Bank::set_interest_rate(Manager.sign(), 1_000u32));
 
 		let amount = 1_000 * DOLLAR;
 
-		assert_ok!(Bank::stake_funds(RuntimeOrigin::signed(ALICE.into()), amount));
+		assert_ok!(Bank::stake_funds(Alice.sign(), amount));
 
 		// Staking period = 2day blocks
 		Bank::on_finalize(System::block_number() + (2 * DAY));
 
-		assert_staked(ALICE.into(), amount);
+		assert_staked(Alice.account(), amount);
 
 		// InterestPayoutPeriod = 1day blocks
 		Bank::on_finalize(DAY);
 
 		let interest = pallet_bank::InterestRate::<Runtime>::get() / 365u128 * amount;
-		assert_staked(ALICE.into(), amount + interest);
+		assert_staked(Alice.account(), amount + interest);
 
 		// Change to a higher interest rate 20%.
-		assert_ok!(Bank::set_interest_rate(RuntimeOrigin::signed(MANAGER.into()), 2_000u32));
+		assert_ok!(Bank::set_interest_rate(Manager.sign(), 2_000u32));
 
 		// Verify
 		Bank::on_finalize(DAY);
 		let staked_2 = amount + interest;
 		let interest_2 = pallet_bank::InterestRate::<Runtime>::get() / 365u128 * staked_2;
-		assert_staked(ALICE.into(), staked_2 + interest_2);
+		assert_staked(Alice.account(), staked_2 + interest_2);
 
 		// Change to a lower interest rate 5%.
-		assert_ok!(Bank::set_interest_rate(RuntimeOrigin::signed(MANAGER.into()), 500u32));
+		assert_ok!(Bank::set_interest_rate(Manager.sign(), 500u32));
 
 		// Verify
 		Bank::on_finalize(DAY);
 		let staked_3 = staked_2 + interest_2;
 		let interest_3 = pallet_bank::InterestRate::<Runtime>::get() / 365u128 * staked_3;
-		assert_staked(ALICE.into(), staked_3 + interest_3);
+		assert_staked(Alice.account(), staked_3 + interest_3);
+
+		println!("{}", Gov0);
 	});
 }

--- a/integration-tests/src/bank.rs
+++ b/integration-tests/src/bank.rs
@@ -38,8 +38,6 @@ fn can_set_and_accrue_interest_rate() {
 		let staked_3 = staked_2 + interest_2;
 		let interest_3 = pallet_bank::InterestRate::<Runtime>::get() / 365u128 * staked_3;
 		assert_staked(Alice.account(), staked_3 + interest_3);
-
-		println!("{}", Gov0);
 	});
 }
 

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -28,20 +28,20 @@ macro_rules! test_account {
 			pub fn sign(&self) -> RuntimeOrigin {
 				RuntimeOrigin::signed(self.account())
 			}
+
+			pub fn to_string(&self) -> String {
+				format!(
+					"{}: 0x{}",
+					stringify!($name),
+					$id.iter().map(|byte| { format!("{:02x}", byte) }).collect::<String>()
+				)
+			}
 		}
 
 		impl std::fmt::Display for $name {
 			fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 				// Convert the array of bytes to a hexadecimal string
-				fn hex_encode(bytes: [u8; 32]) -> String {
-					let mut result = String::new();
-					for byte in bytes.iter() {
-						result.push_str(&format!("{:02x}", byte));
-					}
-					result
-				}
-				let hex_string = format!("0x{:0>64}", hex_encode($id));
-				write!(f, "{}: {:?}", stringify!($name), hex_string)
+				write!(f, "{}", self.to_string())
 			}
 		}
 	};

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -47,15 +47,18 @@ macro_rules! test_account {
 	};
 }
 
+// Customers
 test_account!(Alice, [0x00; 32]);
 test_account!(Bob, [0x01; 32]);
 test_account!(Charlie, [0x02; 32]);
 test_account!(Dave, [0x03; 32]);
 test_account!(Eve, [0x04; 32]);
 
+// Bank manager + auditor
 test_account!(Manager, [0xFF; 32]);
 test_account!(Auditor, [0xFE; 32]);
 
+// Default governance members
 test_account!(Gov0, [0xF0; 32]);
 test_account!(Gov1, [0xF1; 32]);
 test_account!(Gov2, [0xF2; 32]);

--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -16,21 +16,49 @@ mod bank;
 
 pub const INITIAL_BALANCE: Balance = 1_000_000 * DOLLAR;
 
-pub const MANAGER: [u8; 32] = [0xFF; 32];
-pub const AUDITOR: [u8; 32] = [0xFE; 32];
-pub const ALICE: [u8; 32] = [0x00; 32];
-pub const BOB: [u8; 32] = [0x01; 32];
-pub const CHARLIE: [u8; 32] = [0x02; 32];
-pub const DAVE: [u8; 32] = [0x03; 32];
-pub const EVE: [u8; 32] = [0x04; 32];
+macro_rules! test_account {
+	($name:ident, $id:expr) => {
+		pub struct $name;
 
-pub const GOV_0: [u8; 32] = [0xF0; 32];
-pub const GOV_1: [u8; 32] = [0xF1; 32];
-pub const GOV_2: [u8; 32] = [0xF2; 32];
+		impl $name {
+			pub fn account(&self) -> AccountId {
+				$id.into()
+			}
 
-// TODO: use macro to convert these [] into AccountIds.
-// i.e. alice() will return AccountId([0x00; 32]);
-// Issue #52
+			pub fn sign(&self) -> RuntimeOrigin {
+				RuntimeOrigin::signed(self.account())
+			}
+		}
+
+		impl std::fmt::Display for $name {
+			fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+				// Convert the array of bytes to a hexadecimal string
+				fn hex_encode(bytes: [u8; 32]) -> String {
+					let mut result = String::new();
+					for byte in bytes.iter() {
+						result.push_str(&format!("{:02x}", byte));
+					}
+					result
+				}
+				let hex_string = format!("0x{:0>64}", hex_encode($id));
+				write!(f, "{}: {:?}", stringify!($name), hex_string)
+			}
+		}
+	};
+}
+
+test_account!(Alice, [0x00; 32]);
+test_account!(Bob, [0x01; 32]);
+test_account!(Charlie, [0x02; 32]);
+test_account!(Dave, [0x03; 32]);
+test_account!(Eve, [0x04; 32]);
+
+test_account!(Manager, [0xFF; 32]);
+test_account!(Auditor, [0xFE; 32]);
+
+test_account!(Gov0, [0xF0; 32]);
+test_account!(Gov1, [0xF1; 32]);
+test_account!(Gov2, [0xF2; 32]);
 
 pub struct ExtBuilder {
 	governance_members: Vec<AccountId>,
@@ -41,22 +69,22 @@ pub struct ExtBuilder {
 impl Default for ExtBuilder {
 	fn default() -> Self {
 		Self {
-			governance_members: vec![GOV_0.into(), GOV_1.into(), GOV_2.into()],
+			governance_members: vec![Gov0.account(), Gov1.account(), Gov2.account()],
 			balances: vec![
-				(ALICE.into(), INITIAL_BALANCE),
-				(BOB.into(), INITIAL_BALANCE),
-				(CHARLIE.into(), INITIAL_BALANCE),
-				(DAVE.into(), INITIAL_BALANCE),
-				(EVE.into(), INITIAL_BALANCE),
+				(Alice.account(), INITIAL_BALANCE),
+				(Bob.account(), INITIAL_BALANCE),
+				(Charlie.account(), INITIAL_BALANCE),
+				(Dave.account(), INITIAL_BALANCE),
+				(Eve.account(), INITIAL_BALANCE),
 			],
 			roles: vec![
-				(MANAGER.into(), Role::Manager),
-				(AUDITOR.into(), Role::Auditor),
-				(ALICE.into(), Role::Customer),
-				(BOB.into(), Role::Customer),
-				(CHARLIE.into(), Role::Customer),
-				(DAVE.into(), Role::Customer),
-				(EVE.into(), Role::Customer),
+				(Manager.account(), Role::Manager),
+				(Auditor.account(), Role::Auditor),
+				(Alice.account(), Role::Customer),
+				(Bob.account(), Role::Customer),
+				(Charlie.account(), Role::Customer),
+				(Dave.account(), Role::Customer),
+				(Eve.account(), Role::Customer),
 			],
 		}
 	}


### PR DESCRIPTION
Close #52 

Added macro that created test account struct
So that with any name.account() will return the account ID
name.sign() will return RuntimeOrigin.
