### PR TITLE
feature/integration test for lottery pallet

### DIFF
--- a/integration-tests/src/lib.rs
+++ b/integration-tests/src/lib.rs
@@ -68,6 +68,9 @@ test_account!(Gov2, [0xF2; 32]);
 // Default treasury account
 test_account!(Treasury, [0xE0; 32]);
 
+// PrizePoolAccount which is from Runtime
+test_account!(PrizePool, [0xFF; 32]);
+
 pub struct ExtBuilder {
 	governance_members: Vec<AccountId>,
 	balances: Vec<(AccountId, Balance)>,

--- a/integration-tests/src/lottery.rs
+++ b/integration-tests/src/lottery.rs
@@ -26,7 +26,7 @@ fn can_set_and_accrue_lottery_prize_split() {
 		assert_balance(Dave.account(), INITIAL_BALANCE - 40 * DOLLAR);
 
 		//PrizePoolAccount: AccountId = AccountId::from([0xFF; 32]);
-		assert_balance([0xFF; 32].into(), 100 * DOLLAR);
+		assert_balance(PrizePool.account(), 100 * DOLLAR);
 
 		// LotteryPayoutPeriod is one DAY
 		Lottery::on_finalize(DAY);
@@ -40,7 +40,7 @@ fn can_set_and_accrue_lottery_prize_split() {
 			println!("{:?} won. Amount: {}, tax: {}", user, won_fund, tax);
 			assert_balance(user, INITIAL_BALANCE - 40 * DOLLAR + won_fund);
 			assert_balance(Treasury.account(), tax);
-			assert_balance([0xFF; 32].into(), 0);
+			assert_balance(PrizePool.account(), 0);
 		} else {
 			panic!("Last event is not LotteryWon. Events: \n{:?}", System::events());
 		}
@@ -103,6 +103,152 @@ fn can_set_and_accrue_lottery_prize_split() {
 				user: Bob.account(),
 				won_fund: won_2,
 				tax: tax_2,
+			},
+		));
+	});
+}
+
+#[test]
+fn can_draw_lottery_without_enough_winners() {
+	ExtBuilder::default().build().execute_with(|| {
+		// first round with default prize split.
+		assert_ok!(Lottery::buy_ticket(Alice.sign(), 100));
+
+		// Verify
+		System::assert_has_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::TicketsBought {
+				id: Alice.account(),
+				number: 100u32,
+				total_price: 100 * DOLLAR,
+			},
+		));
+
+		assert_balance(Alice.account(), INITIAL_BALANCE - 100 * DOLLAR);
+
+		//PrizePoolAccount: AccountId = AccountId::from([0xFF; 32]);
+		assert_balance(PrizePool.account(), 100 * DOLLAR);
+
+		// Governance set prize split.
+		let prize_split = vec![Percent::from_percent(80), Percent::from_percent(20)];
+		let call = Box::new(RuntimeCall::Lottery(pallet_lottery::Call::set_prize_split {
+			prize_split: prize_split.clone(),
+		}));
+		assert_ok!(Governance::initiate_proposal(Gov0.sign(), call));
+		assert_ok!(Governance::vote(Gov1.sign(), 1, true));
+		assert_ok!(Governance::vote(Gov2.sign(), 1, true));
+
+		Governance::on_finalize(System::block_number());
+
+		assert_eq!(Lottery::prize_split(), prize_split.clone());
+
+		Lottery::on_finalize(DAY);
+
+		// Verify
+		let won_1 = prize_split[0] * Percent::from_percent(95) * 100 * DOLLAR;
+		let tax_1 = prize_split[0] * Percent::from_percent(5) * 100 * DOLLAR;
+		let rest = prize_split[1] * 100 * DOLLAR;
+
+		assert_balance(Alice.account(), INITIAL_BALANCE - 100 * DOLLAR + won_1);
+
+		// Check the treasury account received the tax.
+		assert_balance(Treasury.account(), tax_1);
+
+		// Check the rest prize is stay in the prize pool account for next round lottery draw.
+		assert_balance(PrizePool.account(), rest);
+
+		System::assert_has_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::LotteryWon {
+				user: Alice.account(),
+				won_fund: won_1,
+				tax: tax_1,
+			},
+		));
+
+		// Test the second round if the winner is enough, then all the fund from prize pool will
+		// draw to the winners.
+		assert_ok!(Lottery::buy_ticket(Bob.sign(), 50));
+		assert_ok!(Lottery::buy_ticket(Charlie.sign(), 50));
+
+		Lottery::on_finalize(DAY);
+
+		// Verify
+		let won = prize_split[0] * Percent::from_percent(95) * (100 * DOLLAR + rest);
+		let tax = prize_split[0] * Percent::from_percent(5) * (100 * DOLLAR + rest);
+		let won_2 = prize_split[1] * Percent::from_percent(95) * (100 * DOLLAR + rest);
+		let tax_2 = prize_split[1] * Percent::from_percent(5) * (100 * DOLLAR + rest);
+
+		assert_balance(Bob.account(), INITIAL_BALANCE - 50 * DOLLAR + won);
+		assert_balance(Charlie.account(), INITIAL_BALANCE - 50 * DOLLAR + won_2);
+
+		// Check the treasury account received the tax.
+		assert_balance(Treasury.account(), tax_1 + tax + tax_2);
+
+		// Check the rest prize is stay in the prize pool account for next round lottery draw.
+		assert_balance(PrizePool.account(), 0);
+
+		System::assert_has_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::LotteryWon {
+				user: Bob.account(),
+				won_fund: won,
+				tax,
+			},
+		));
+		System::assert_last_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::LotteryWon {
+				user: Charlie.account(),
+				won_fund: won_2,
+				tax: tax_2,
+			},
+		));
+	});
+}
+
+#[test]
+fn can_force_draw_lottery() {
+	ExtBuilder::default().build().execute_with(|| {
+		// first round with default prize split.
+		assert_ok!(Lottery::buy_ticket(Alice.sign(), 80));
+		assert_ok!(Lottery::buy_ticket(Bob.sign(), 20));
+
+		// Verify
+		System::assert_has_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::TicketsBought {
+				id: Alice.account(),
+				number: 80u32,
+				total_price: 80 * DOLLAR,
+			},
+		));
+
+		assert_balance(Alice.account(), INITIAL_BALANCE - 80 * DOLLAR);
+
+		//PrizePoolAccount: AccountId = AccountId::from([0xFF; 32]);
+		assert_balance(PrizePool.account(), 100 * DOLLAR);
+
+		// Governance force draw.
+		let call = Box::new(RuntimeCall::Lottery(pallet_lottery::Call::force_draw {}));
+		assert_ok!(Governance::initiate_proposal(Gov0.sign(), call));
+		assert_ok!(Governance::vote(Gov1.sign(), 1, true));
+		assert_ok!(Governance::vote(Gov2.sign(), 1, true));
+
+		Governance::on_finalize(System::block_number());
+
+		Lottery::on_finalize(System::block_number());
+
+		// Verify
+		let won = Percent::from_percent(95) * 100 * DOLLAR;
+		let tax = Percent::from_percent(5) * 100 * DOLLAR;
+
+		assert_balance(Alice.account(), INITIAL_BALANCE - 80 * DOLLAR);
+		assert_balance(Bob.account(), INITIAL_BALANCE - 20 * DOLLAR + won);
+
+		// Check the treasury account received the tax.
+		assert_balance(Treasury.account(), tax);
+
+		System::assert_last_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::LotteryWon {
+				user: Bob.account(),
+				won_fund: won,
+				tax,
 			},
 		));
 	});

--- a/integration-tests/src/lottery.rs
+++ b/integration-tests/src/lottery.rs
@@ -1,0 +1,109 @@
+use core::panic;
+
+use crate::*;
+
+#[test]
+fn can_set_and_accrue_lottery_prize_split() {
+	ExtBuilder::default().build().execute_with(|| {
+		// first round with default prize split.
+		assert_ok!(Lottery::buy_ticket(Alice.sign(), 10));
+		assert_ok!(Lottery::buy_ticket(Bob.sign(), 20));
+		assert_ok!(Lottery::buy_ticket(Charlie.sign(), 30));
+		assert_ok!(Lottery::buy_ticket(Dave.sign(), 40));
+
+		// Verify
+		System::assert_has_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::TicketsBought {
+				id: Alice.account(),
+				number: 10u32,
+				total_price: 10 * DOLLAR,
+			},
+		));
+
+		assert_balance(Alice.account(), INITIAL_BALANCE - 10 * DOLLAR);
+		assert_balance(Bob.account(), INITIAL_BALANCE - 20 * DOLLAR);
+		assert_balance(Charlie.account(), INITIAL_BALANCE - 30 * DOLLAR);
+		assert_balance(Dave.account(), INITIAL_BALANCE - 40 * DOLLAR);
+
+		//PrizePoolAccount: AccountId = AccountId::from([0xFF; 32]);
+		assert_balance([0xFF; 32].into(), 100 * DOLLAR);
+
+		// LotteryPayoutPeriod is one DAY
+		Lottery::on_finalize(DAY);
+
+		if let RuntimeEvent::Lottery(pallet_lottery::Event::<Runtime>::LotteryWon {
+			user,
+			won_fund,
+			tax,
+		}) = System::events().into_iter().last().unwrap().event
+		{
+			println!("{:?} won. Amount: {}, tax: {}", user, won_fund, tax);
+			assert_balance(user, INITIAL_BALANCE - 40 * DOLLAR + won_fund);
+			assert_balance(Treasury.account(), tax);
+			assert_balance([0xFF; 32].into(), 0);
+		} else {
+			panic!("Last event is not LotteryWon. Events: \n{:?}", System::events());
+		}
+
+		// Governance set prize split.
+		let prize_split = vec![Percent::from_percent(80), Percent::from_percent(20)];
+		let call = Box::new(RuntimeCall::Lottery(pallet_lottery::Call::set_prize_split {
+			prize_split: prize_split.clone(),
+		}));
+		assert_ok!(Governance::initiate_proposal(Gov0.sign(), call));
+		assert_ok!(Governance::vote(Gov1.sign(), 1, true));
+		assert_ok!(Governance::vote(Gov2.sign(), 1, true));
+
+		Governance::on_finalize(System::block_number());
+
+		assert_eq!(Lottery::prize_split(), prize_split.clone());
+
+		// Second round lottery with new prize split.
+		assert_ok!(Lottery::buy_ticket(Alice.sign(), 10));
+		assert_ok!(Lottery::buy_ticket(Bob.sign(), 20));
+		assert_ok!(Lottery::buy_ticket(Charlie.sign(), 30));
+		assert_ok!(Lottery::buy_ticket(Dave.sign(), 40));
+
+		// Verify
+		System::assert_has_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::TicketsBought {
+				id: Alice.account(),
+				number: 10u32,
+				total_price: 10 * DOLLAR,
+			},
+		));
+		// Alice bought 20 tickets in total.
+		assert_balance(Alice.account(), INITIAL_BALANCE - 20 * DOLLAR);
+
+		Lottery::on_finalize(DAY);
+
+		let won_1 = prize_split[0] * Percent::from_percent(95) * 100 * DOLLAR;
+		let won_2 = prize_split[1] * Percent::from_percent(95) * 100 * DOLLAR;
+		let tax_1 = prize_split[0] * Percent::from_percent(5) * 100 * DOLLAR;
+		let tax_2 = prize_split[1] * Percent::from_percent(5) * 100 * DOLLAR;
+
+		assert_balance(Dave.account(), INITIAL_BALANCE - 80 * DOLLAR + 95 * DOLLAR + won_1);
+		assert_balance(Alice.account(), INITIAL_BALANCE - 20 * DOLLAR);
+		assert_balance(Bob.account(), INITIAL_BALANCE - 40 * DOLLAR + won_2);
+		assert_balance(Charlie.account(), INITIAL_BALANCE - 60 * DOLLAR);
+
+		// Check the treasury account received the tax.
+		assert_balance(Treasury.account(), (tax_1 + tax_2) * 2);
+
+		System::assert_has_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::LotteryWon {
+				user: Dave.account(),
+				won_fund: won_1,
+				tax: tax_1,
+			},
+		));
+
+		System::assert_last_event(RuntimeEvent::Lottery(
+			pallet_lottery::Event::<Runtime>::LotteryWon {
+				user: Bob.account(),
+				won_fund: won_2,
+				tax: tax_2,
+			},
+		));
+	});
+}

--- a/pallets/pallet-bank/src/lib.rs
+++ b/pallets/pallet-bank/src/lib.rs
@@ -302,6 +302,10 @@ pub mod module {
 		) -> DispatchResult {
 			let id = ensure_signed(origin)?;
 			T::RoleManager::ensure_role(&id, Role::Manager)?;
+
+			if amount < T::MinimumAmount::get() {
+				return Err(Error::<T>::AmountTooSmall.into());
+			}
 			<Self as BasicAccounting<T::AccountId, T::Balance>>::deposit(&user, amount)
 		}
 
@@ -317,6 +321,10 @@ pub mod module {
 		) -> DispatchResult {
 			let id = ensure_signed(origin)?;
 			T::RoleManager::ensure_role(&id, Role::Manager)?;
+
+			if amount < T::MinimumAmount::get() {
+				return Err(Error::<T>::AmountTooSmall.into());
+			}
 			<Self as BasicAccounting<T::AccountId, T::Balance>>::withdraw(&user, amount)
 		}
 
@@ -331,6 +339,10 @@ pub mod module {
 			let id = ensure_signed(origin)?;
 			T::RoleManager::ensure_role(&id, Role::Customer)?;
 			T::RoleManager::ensure_role(&to_user, Role::Customer)?;
+
+			if amount < T::MinimumAmount::get() {
+				return Err(Error::<T>::AmountTooSmall.into());
+			}
 			<Self as BasicAccounting<T::AccountId, T::Balance>>::transfer(&id, &to_user, amount)
 		}
 
@@ -495,27 +507,18 @@ pub mod module {
 
 impl<T: Config> BasicAccounting<T::AccountId, T::Balance> for Pallet<T> {
 	fn deposit(user: &T::AccountId, amount: T::Balance) -> DispatchResult {
-		if amount < T::MinimumAmount::get() {
-			return Err(Error::<T>::AmountTooSmall.into());
-		}
 		Self::mint(user, amount)?;
 		Self::deposit_event(Event::<T>::Deposited { user: user.clone(), amount });
 		Ok(())
 	}
 
 	fn withdraw(user: &T::AccountId, amount: T::Balance) -> DispatchResult {
-		if amount < T::MinimumAmount::get() {
-			return Err(Error::<T>::AmountTooSmall.into());
-		}
 		Self::burn(user, amount)?;
 		Self::deposit_event(Event::<T>::Withdrew { user: user.clone(), amount });
 		Ok(())
 	}
 
 	fn transfer(from: &T::AccountId, to: &T::AccountId, amount: T::Balance) -> DispatchResult {
-		if amount < T::MinimumAmount::get() {
-			return Err(Error::<T>::AmountTooSmall.into());
-		}
 		Accounts::<T>::mutate(from, |balance| -> DispatchResult {
 			if balance.free >= amount {
 				balance.free -= amount;


### PR DESCRIPTION
Close #21 

Added integration test for lottery pallet.
Tests customers can buy tickets and the lottery draw successfully.
The governance can change the prize split and the lottery can draw with the new prize split.